### PR TITLE
CSS 수정

### DIFF
--- a/icann-letter-20180213.html
+++ b/icann-letter-20180213.html
@@ -4,7 +4,13 @@
 <meta charset="utf-8" />
 <title>Open Letter to the Proposal for a Korean Script Root Zone LGR | “한국 문자 루트 존 라벨 생성 규칙의 제안”에 대한 공개 서한</title>
 <style>
-body { line-height: 1.5; }
+body {
+	line-height: 1.5;
+	max-width: 1500px;
+	margin: 8px auto;
+	padding: 0 8px;
+}
+
 h1, h2, h3 { font-family: Arial, 맑은 고딕, Malgun Gothic, sans-serif; }
 h1 { font-size: 200%; margin: 0; }
 h2 { font-size: 180%; margin: 1em 0 0 0;  }

--- a/icann-letter-20180213.html
+++ b/icann-letter-20180213.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
 <head>
-<meta charset="utf-8" />
+<meta charset="utf-8">
 <title>Open Letter to the Proposal for a Korean Script Root Zone LGR | “한국 문자 루트 존 라벨 생성 규칙의 제안”에 대한 공개 서한</title>
 <style>
 body {

--- a/icann-letter-20180213.html
+++ b/icann-letter-20180213.html
@@ -9,6 +9,7 @@ body {
 	max-width: 1500px;
 	margin: 8px auto;
 	padding: 0 8px;
+	overflow-wrap: break-word;
 }
 
 h1, h2, h3 { font-family: Arial, 맑은 고딕, Malgun Gothic, sans-serif; }

--- a/icann-letter-20180213.html
+++ b/icann-letter-20180213.html
@@ -2,6 +2,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Open Letter to the Proposal for a Korean Script Root Zone LGR | “한국 문자 루트 존 라벨 생성 규칙의 제안”에 대한 공개 서한</title>
 <style>
 body {
@@ -29,9 +30,35 @@ p.fn sup { font-size: inherit; vertical-align: inherit; }
 a { color: #00007f; text-decoration: underline; }
 [lang|=en] { width: 49%; float: left; clear: both; }
 [lang|=ko] { width: 49%; float: right; }
+
+nav {
+	display: none;
+	position: absolute;
+	background-color: #333;
+	color: white;
+	top: 0;
+	left: 0;
+	right: 0;
+	line-height: 25px;
+	text-align: right;
+	padding: 0 15px;
+}
+nav > a { color: white; }
+@media only screen and (max-width: 450px) {
+	body { margin-top: 30px; }
+	nav { display: block; }
+	[lang|=en], [lang|=ko] { width: 100%; float: none; }
+	body[data-display-language|=ko] [lang|=en],
+	body[data-display-language|=en] [lang|=ko] { display: none; }
+}
 </style>
 <head>
-<body>
+<body data-display-language=ko>
+<nav>
+	<a lang="ko" onclick="document.body.dataset.displayLanguage='en'">Show in English</a>
+	<a lang="en" onclick="document.body.dataset.displayLanguage='ko'">한국어로 보기</a>
+</nav>
+
 <h1 lang="en">Open Letter to the Proposal for a Korean Script Root Zone LGR</h1>
 <h1 lang="ko">“한국 문자 루트 존 라벨 생성 규칙의 제안”에 대한 공개 서한</h1>
 <p lang="en">Authors: Jaemin Chung, Seonghoon Kang, Shinjo Park</p>

--- a/insult-from-kisa-20180426.html
+++ b/insult-from-kisa-20180426.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <title>한국인터넷진흥원 측의 모욕 사건에 대한 공개 서한</title>
 <style>
 body {

--- a/insult-from-kisa-20180426.html
+++ b/insult-from-kisa-20180426.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="ko">
 <head>
-<meta charset="utf-8" />
+<meta charset="utf-8">
 <title>한국인터넷진흥원 측의 모욕 사건에 대한 공개 서한</title>
 <style>
 body {

--- a/insult-from-kisa-20180426.html
+++ b/insult-from-kisa-20180426.html
@@ -4,7 +4,13 @@
 <meta charset="utf-8" />
 <title>한국인터넷진흥원 측의 모욕 사건에 대한 공개 서한</title>
 <style>
-body { line-height: 1.5; }
+body {
+	line-height: 1.5;
+	max-width: 800px;
+	margin: 30px auto 50px;
+	padding: 0 8px;
+}
+
 h1, h2, h3 { font-family: Arial, 맑은 고딕, Malgun Gothic, sans-serif; }
 h1 { font-size: 200%; margin: 0; }
 h2 { font-size: 180%; margin: 1em 0 0 0;  }


### PR DESCRIPTION
1. 너무 큰 모니터에서 문단이 지나치가 좌우로 길어지지 않도록 수정함
1. 모바일에서 기본으로 줌아웃된 상태로 보여지지 않도록 메타데이터 설정
1. icann-letter-20180213.html 문서가 특정 화면 크기에서 너무 긴 하이퍼링크때문에 레이아웃이 왼쪽으로 밀리는 문제 고침
1. icann-letter-20180213.html 의 경우, 모바일에서 영어/한국어 컨텐츠를 모두 표시하기 힘들어, 표시 언어를 선택 가능하도록 수정함
1. (misc) HTML 마크업 살짝 수정